### PR TITLE
Fix vhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN docker-php-ext-install -j$(nproc) tidy gettext intl mysqli pdo_mysql && \
 
 # Enabling apache vhost
 COPY vhost.conf /etc/apache2/sites-available/vhost.conf
+RUN a2dissite * && a2ensite vhost.conf
 
 # Changing DOCUMENT ROOT
 RUN mkdir /var/www/galette

--- a/vhost.conf
+++ b/vhost.conf
@@ -1,10 +1,14 @@
 <VirtualHost *:80>
     ServerName galette.localhost
 
-    https - add *:443 in the <VirtualHost>
-    SSLEngine on
-    SSLProtocol all -SSLv2 -SSLv3
-    Header always add Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
+    #https - add *:443 in the <VirtualHost>
+    #SSLEngine on
+    #SSLProtocol all -SSLv2 -SSLv3
+    #Header always add Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
+
+    #SSLCertificateFile /etc/pki/tls/certs/galette.localhost.crt
+    #SSLCertificateChainFile /etc/pki/tls/certs/galette.localhost.chain.crt
+    #SSLCertificateKeyFile /etc/pki/tls/private/galette.localhost.key
 
     DocumentRoot /var/www/galette/webroot/
     <Directory /var/www/galette/webroot/>


### PR DESCRIPTION
Hi!

Currently image doesn't make use of the `vhost.conf` file (not symlinked in `./sites-enabled/`).  
It causes paths to not be rewritten (eg: `http://127.0.0.1/webroot/index.php/login`)

This PR fixes that by adding a `RUN a2dissite * && a2ensite vhost.conf` to the `Dockerfile` after copying the file. The `a2dissite *` instruction is to make sure all defaults are disabled.  
It also fixes the `vhost.conf` file.  
Result is path correctly rewritten (eg: `http://127.0.0.1/login`)  

*Note*: There's an error at new install PDF Models init step but it happens on both current and this PR's versions of the image. Trying to determine if present outside of docker context. It doesn't seems to prevent Galette from being usable.
