### PR TITLE
Use HOSTNAME envvar for servername

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN docker-php-ext-install -j$(nproc) tidy gettext intl mysqli pdo_mysql && \
 
 # Enabling apache vhost
 COPY vhost.conf /etc/apache2/sites-available/vhost.conf
-RUN a2dissite * && a2ensite vhost.conf
+RUN sed -i 's/galette.localhost/galette.${HOSTNAME}/' /etc/apache2/sites-available/vhost.conf \
+    && a2dissite * && a2ensite vhost.conf
 
 # Changing DOCUMENT ROOT
 RUN mkdir /var/www/galette


### PR DESCRIPTION
Pretty self explanatory, resulting hostname in logs is now different from a container to another (eg `galette.e47754f22c0f:80`).  
Added as `RUN` instruction in `Dockerfile` to keep `vhost.conf` as close as possible to the documentation example.  
